### PR TITLE
Add /verify endpoint spec

### DIFF
--- a/pkg/types/zz_generated.go
+++ b/pkg/types/zz_generated.go
@@ -267,6 +267,12 @@ type UserOptions struct {
 	Password    string  `json:"password"`
 }
 
+// VerifyOptions defines model for verify_options.
+type VerifyOptions struct {
+	Code string `json:"code"`
+	Type string `json:"type"`
+}
+
 // Workload defines model for workload.
 type Workload struct {
 	Condition            *string                 `json:"condition,omitempty"`

--- a/spec/backend.yaml
+++ b/spec/backend.yaml
@@ -936,6 +936,20 @@ paths:
         401: {}
         422: {}
         500: {}
+  /v1/verify:
+    post:
+      operationId: verify
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'types.yaml#/components/schemas/verify_options'
+      responses:
+        202: {}
+        401: {}
+        422: {}
+        500: {}
 components:
   securitySchemas:
     bearerAuth:

--- a/spec/types.yaml
+++ b/spec/types.yaml
@@ -439,6 +439,15 @@ components:
           type: string
         credential_reference_name:
           type: string
+    verify_options:
+      properties:
+        type:
+          type: string
+        code:
+          type: string
+      required:
+      - type
+      - code
     user_options:
       properties:
         display_name:


### PR DESCRIPTION
We're planning on moving `/verify` endpoint from dockyards-serverside to
dockyards-backend to streamline verification process.

This commit adds the corresponding spec to dockyards-backend
